### PR TITLE
Refactor(Board): refactor BoardViewModel functions

### DIFF
--- a/app/src/main/java/com/example/podomarket/product/ProductAddFragment.kt
+++ b/app/src/main/java/com/example/podomarket/product/ProductAddFragment.kt
@@ -118,23 +118,31 @@ class ProductAddFragment : Fragment() {
                     Toast.makeText(requireContext(), "내용을 입력해주세요", Toast.LENGTH_SHORT).show()
                 } else {
                     val createdAt = Timestamp(Date())
-                    val sold = false
-                    var userName = ""
-                    // 비동기문제때문에 괄호위치 아래처럼 해야함
-                    authViewModel.getUser(userId) { email, name ->
-                        userName = name
+//                    val sold = false
+//                    var userName = ""
 
-                        Toast.makeText(requireContext(), "userName: $userName", Toast.LENGTH_SHORT)
-
-                        // 검증 통과후 판매글 업로드(addBoard함수가 suspend처리되어있어 코루틴 내에서 호출해야한다)
-                        CoroutineScope(Dispatchers.Main).launch {
-                            boardViewModel.addBoard(content, createdAt, pictures, price, sold, title, userId, userName
-                            ) { isSuceess ->
-                                if (isSuceess) moveListFragment()
-                                else Toast.makeText(requireContext(), "업로드 실패, 내용을 추가 또는 수정해주세요", Toast.LENGTH_SHORT).show()
-                            }
+                    CoroutineScope(Dispatchers.Main).launch {
+                        boardViewModel.addBoard(content, createdAt, pictures, price, title) { isSuceess ->
+                            if (isSuceess) moveListFragment()
+                            else Toast.makeText(requireContext(), "업로드 실패, 내용을 추가 또는 수정해주세요", Toast.LENGTH_SHORT).show()
                         }
                     }
+
+//                    // 비동기문제때문에 괄호위치 아래처럼 해야함
+//                    authViewModel.getUser(userId) { email, name ->
+//                        userName = name
+//
+//                        Toast.makeText(requireContext(), "userName: $userName", Toast.LENGTH_SHORT)
+//
+//                        // 검증 통과후 판매글 업로드(addBoard함수가 suspend처리되어있어 코루틴 내에서 호출해야한다)
+//                        CoroutineScope(Dispatchers.Main).launch {
+//                            boardViewModel.addBoard(content, createdAt, pictures, price, sold, title, userId, userName
+//                            ) { isSuceess ->
+//                                if (isSuceess) moveListFragment()
+//                                else Toast.makeText(requireContext(), "업로드 실패, 내용을 추가 또는 수정해주세요", Toast.LENGTH_SHORT).show()
+//                            }
+//                        }
+//                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/podomarket/product/ProductEditFragment.kt
+++ b/app/src/main/java/com/example/podomarket/product/ProductEditFragment.kt
@@ -165,12 +165,12 @@ class ProductEditFragment : Fragment() {
                         else -> false
                     }
                     // 검증 통과 후 판매글 업로드
-                    boardViewModel.updateBoard(board.uuid, BoardModel(board.uuid, content, board.createdAt, board.pictures, price, sold, title, board.userId, board.userName)
-                    ) { isSuccess ->
-                        if (isSuccess) moveDetailFragment()
-                        else Toast.makeText(requireContext(), "내용 수정 실패, 내용을 다시 수정해주세요", Toast.LENGTH_SHORT
-                        ).show()
-                    }
+//                    boardViewModel.updateBoard(board.uuid, BoardModel(board.uuid, content, board.createdAt, board.pictures, price, sold, title, board.userId, board.userName)
+//                    ) { isSuccess ->
+//                        if (isSuccess) moveDetailFragment()
+//                        else Toast.makeText(requireContext(), "내용 수정 실패, 내용을 다시 수정해주세요", Toast.LENGTH_SHORT
+//                        ).show()
+//                    }
                 }
             }
         }


### PR DESCRIPTION
- Board(Firestore)에 deleted 필드를 추가하여 getAllBoards 호출 시에 deleted를 필터링 합니다.
- getAllBoards 할 때 시간 차순 정렬이 반대로 되어 있어 다시 수정하였습니다.
-  addBoard의 파라미터를 일부 수정하여 sold, userId, userName은 안 받을 수 있도록 조정하였습니다. (ProductAddFragment에 반영하였으니 확인해주세요! 기존 코드는 주석 처리 해두었습니다.)
- deleteBoard 함수 추가하였습니다. (deleted 필드를 true로 바꿈)
- updateBoard 함수에 newPictures: List<File> 파라미터를 추가하여 추가적인 newPictures가 들어오면 기존 pictures: List<String>와 결합하여 DB에 업데이트 됩니다. (Test required) -> ProductEditFragment에 추가적인 반영이 필요합니다!