### PR TITLE
Feature&Refactor(#28): Board / Chat ViewModel Updates

### DIFF
--- a/app/src/main/java/com/example/podomarket/TestActivity.kt
+++ b/app/src/main/java/com/example/podomarket/TestActivity.kt
@@ -2,6 +2,7 @@ package com.example.podomarket
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import com.example.podomarket.product.ProductListFragment
 import com.example.podomarket.viewmodel.ChatViewModel
 
@@ -12,10 +13,9 @@ class TestActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_market)
 
-        // 채팅방 변경되었을 때 Listener를 등록해서
         chatViewModel.chatCollection.addSnapshotListener { snapshot, _ ->
             for (dc in snapshot!!.documentChanges) {
-                chatViewModel.getMyAllChatRooms("myuid") {
+                chatViewModel.getAllMyChatRooms {
                     // 다시 업데이트 가능
                 }
 

--- a/app/src/main/java/com/example/podomarket/model/ChatModel.kt
+++ b/app/src/main/java/com/example/podomarket/model/ChatModel.kt
@@ -5,7 +5,8 @@ import com.google.firebase.Timestamp
 data class ChatRoomModel(
     val boardUuid: String,
     val chats: List<ChatModel>,
-    val participants: List<String>
+    val participants: List<String>,
+    val recentTime: Timestamp
 )
 
 data class ChatModel(

--- a/app/src/main/java/com/example/podomarket/product/ProductAddFragment.kt
+++ b/app/src/main/java/com/example/podomarket/product/ProductAddFragment.kt
@@ -121,11 +121,9 @@ class ProductAddFragment : Fragment() {
 //                    val sold = false
 //                    var userName = ""
 
-                    CoroutineScope(Dispatchers.Main).launch {
-                        boardViewModel.addBoard(content, createdAt, pictures, price, title) { isSuceess ->
-                            if (isSuceess) moveListFragment()
-                            else Toast.makeText(requireContext(), "업로드 실패, 내용을 추가 또는 수정해주세요", Toast.LENGTH_SHORT).show()
-                        }
+                    boardViewModel.addBoard(content, createdAt, pictures, price, title) { isSuceess ->
+                        if (isSuceess) moveListFragment()
+                        else Toast.makeText(requireContext(), "업로드 실패, 내용을 추가 또는 수정해주세요", Toast.LENGTH_SHORT).show()
                     }
 
 //                    // 비동기문제때문에 괄호위치 아래처럼 해야함

--- a/app/src/main/java/com/example/podomarket/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/podomarket/viewmodel/AuthViewModel.kt
@@ -60,6 +60,7 @@ class AuthViewModel : ViewModel() {
                     .set(
                         hashMapOf(
                             "birth" to birth,
+                            "chats" to emptyList<String>(),
                             "name" to name,
                             "email" to email,
                         )

--- a/app/src/main/java/com/example/podomarket/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/podomarket/viewmodel/AuthViewModel.kt
@@ -22,12 +22,12 @@ class AuthViewModel : ViewModel() {
             }
     }
 
-    fun getCurrentUser(onGetCurrentUserComplete: (email: String, name: String) -> Unit) {
+    fun getCurrentUser(onGetCurrentUserComplete: (email: String, name: String, chats: List<String>) -> Unit) {
         db.collection("User")
             .document(auth.currentUser?.uid.toString())
             .get()
             .addOnSuccessListener {
-                onGetCurrentUserComplete(it.data?.get("email").toString(), it.data?.get("name").toString())
+                onGetCurrentUserComplete(it.data?.get("email").toString(), it.data?.get("name").toString(), it.data?.get("chats") as List<String>)
             }
     }
 

--- a/app/src/main/java/com/example/podomarket/viewmodel/BoardViewModel.kt
+++ b/app/src/main/java/com/example/podomarket/viewmodel/BoardViewModel.kt
@@ -80,7 +80,7 @@ class BoardViewModel : ViewModel() {
             }.await()
         }
 
-        authViewModel.getCurrentUser { _, name ->
+        authViewModel.getCurrentUser { _, name, _ ->
             boardCollection
                 .add(
                     hashMapOf(

--- a/app/src/main/java/com/example/podomarket/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/example/podomarket/viewmodel/ChatViewModel.kt
@@ -1,44 +1,54 @@
 package com.example.podomarket.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import com.example.podomarket.model.ChatModel
 import com.example.podomarket.model.ChatRoomModel
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class ChatViewModel : ViewModel() {
     private val db = FirebaseFirestore.getInstance()
+    private val authViewModel = AuthViewModel()
+    private val userCollection = db.collection("User")
     val chatCollection = db.collection("Chat")
 
-    fun getMyAllChatRooms(uid: String, onComplete: (List<ChatRoomModel>) -> Unit) {
-        chatCollection.addSnapshotListener { snapshot, error ->
-            if (error != null) {
-                return@addSnapshotListener
-            }
-
+    fun getAllMyChatRooms(onComplete: (List<ChatRoomModel>) -> Unit) {
+        authViewModel.getCurrentUser { _, _, chats_uiid ->
             val myChatRooms = mutableListOf<ChatRoomModel>()
 
-            snapshot?.forEach { document ->
-                val participants = document.get("participants") as List<String>
+            CoroutineScope(Dispatchers.Main).launch {
+                chats_uiid.forEach { chat_uuid ->
+                    chatCollection.document(chat_uuid)
+                        .get()
+                        .addOnSuccessListener { document ->
+                            val boardId = document.get("board_id") as String
+                            val chats = document.get("chats") as List<HashMap<String, Any>>
+                            val participants = document.get("participants") as List<String>
+                            val recentTime = document.get("recent_time") as Timestamp
 
-                if (participants.contains(uid)) {
-                    val boardId = document.get("board_id") as String
-                    val chats = document.get("chats") as List<HashMap<String, Any>>
+                            val chatsList = mutableListOf<ChatModel>()
 
-                    val chatsList = mutableListOf<ChatModel>()
+                            chats.forEach {
+                                val createdAt = it["created_at"] as Timestamp
+                                val message = it["message"] as String
+                                val userId = it["user_id"] as String
+                                val userName = it["user_name"] as String
 
-                    chats.forEach {
-                        val createdAt = it["created_at"] as Timestamp
-                        val message = it["message"] as String
-                        val userId = it["user_id"] as String
-                        val userName = it["user_name"] as String
+                                chatsList.add(ChatModel(createdAt, message, userId, userName))
+                            }
 
-                        chatsList.add(ChatModel(createdAt, message, userId, userName))
-                    }
+                            myChatRooms.add(ChatRoomModel(boardId, chatsList, participants, recentTime))
+                        }
+                        .await()
+                }
 
-                    myChatRooms.add(ChatRoomModel(boardId, chatsList, participants))
+                myChatRooms.sortByDescending {
+                    it.recentTime
                 }
 
                 onComplete(myChatRooms)
@@ -66,38 +76,67 @@ class ChatViewModel : ViewModel() {
             }
     }
 
-    fun createChatRoom(boardId: String, myUid: String, theOtherUid: String, onCreateComplete: (Boolean) -> Unit) {
-        chatCollection
-            .add(
-                hashMapOf(
-                    "board_id" to boardId,
-                    "chats" to emptyList<HashMap<String, Any>>(),
-                    "participants" to mutableListOf(myUid, theOtherUid),
+    fun createChatRoom(boardId: String, myUid: String, theOtherUid: String, onCreateComplete: (ChatRoomModel) -> Unit) {
+        getAllMyChatRooms { chatRoomModels ->
+            chatRoomModels.forEach { chatRoomModel ->
+                if (chatRoomModel.boardUuid == boardId && chatRoomModel.participants.contains(myUid) && chatRoomModel.participants.contains(theOtherUid)) {
+                    onCreateComplete(chatRoomModel)
+                    return@getAllMyChatRooms
+                }
+            }
+
+            chatCollection
+                .add(
+                    hashMapOf(
+                        "board_id" to boardId,
+                        "chats" to emptyList<HashMap<String, Any>>(),
+                        "participants" to mutableListOf(myUid, theOtherUid),
+                        "recent_time" to Timestamp.now(),
+                    )
                 )
-            )
-            .addOnSuccessListener {
-                onCreateComplete(true)
-            }
-            .addOnFailureListener {
-                onCreateComplete(false)
-            }
+                .addOnSuccessListener {
+                    it.get().addOnSuccessListener { chatDocument ->
+                        CoroutineScope(Dispatchers.Main).launch {
+                            userCollection.document(myUid)
+                                .update("chats", FieldValue.arrayUnion(chatDocument.id))
+                                .await()
+
+                            userCollection.document(theOtherUid)
+                                .update("chats", FieldValue.arrayUnion(chatDocument.id))
+                                .await()
+
+                            onCreateComplete(ChatRoomModel(boardId, emptyList<ChatModel>(), listOf(myUid, theOtherUid), Timestamp.now()))
+                        }
+                    }
+
+                }
+        }
     }
 
-    fun sendChat(chatRoomUuid: String, uid: String, userName: String, message: String, onSendComplete: (Boolean) -> Unit) {
-        val newChatItem = mapOf(
-            "created_at" to Timestamp.now(),
-            "message" to message,
-            "user_id" to uid,
-            "user_name" to userName,
-        )
+    fun sendChat(chatRoomUuid: String, message: String, onSendComplete: (Boolean) -> Unit) {
+        authViewModel.getCurrentUser { _, name, _ ->
+            val newChatItem = mapOf(
+                "created_at" to Timestamp.now(),
+                "message" to message,
+                "user_id" to authViewModel.getCurrentUserUid(),
+                "user_name" to name,
+            )
 
-        chatCollection.document(chatRoomUuid)
-            .update("chats", FieldValue.arrayUnion(newChatItem))
-            .addOnSuccessListener {
-                onSendComplete(true)
-            }
-            .addOnFailureListener {
-                onSendComplete(false)
-            }
+            chatCollection.document(chatRoomUuid)
+                .update("chats", FieldValue.arrayUnion(newChatItem))
+                .addOnSuccessListener {
+                    chatCollection.document(chatRoomUuid)
+                        .update("recent_time", Timestamp.now())
+                        .addOnSuccessListener {
+                            onSendComplete(true)
+                        }
+                        .addOnFailureListener {
+                            onSendComplete(false)
+                        }
+                }
+                .addOnFailureListener {
+                    onSendComplete(false)
+                }
+        }
     }
 }


### PR DESCRIPTION
### ViewModel
View에서 사용하던 Coroutine은 전부 ViewModel 내부에서 돌아가게 재구성 하였습니다.
> addBoard 쓰던 ProductAddFragment는 CoroutineScope 제거함

### Chat

Firestore 필드 수정 및 Model 반영 완료
> Chat Collection에 recent_time: Timestamp 필드 추가 완료
> User Collection에 chats: List<String> 필드 추가 완료 (여기에는 chat uuid 들어가요)
> Model에도 반영 완료

getMyAllChatRooms 함수 파라미터 제거 / User의 chats에 있는 uuid로 채팅방 가져옴 / recent_time 기반 내림차순 정렬 완료

createChatRoom 함수 onCreateComplete Handler에서 return 값 Boolean -> ChatRoomModel 변경
> DetailFragment에서 채팅하러 가기? 그런 버튼 누르면 바로 채팅으로 넘어갈 수 있게 ChatRoomModel로 반환함

createChatRoom 함수에서 내 채팅방 안에 이미 존재하는지 체크 및 있다면 그 채팅방 ChatRoomModel 반환 / 없으면 새로 생성 및 생성된 채팅방 ChatRoomModel 반환

sendChat 함수 파라미터 최소화 / 채팅 보낼 때 Chat의 recent_time 필드에 반영